### PR TITLE
Add apollo-studio-check as a pull_request_target

### DIFF
--- a/.github/workflows/apollo-studio-checks.yml
+++ b/.github/workflows/apollo-studio-checks.yml
@@ -1,0 +1,25 @@
+name: Check GraphQL Schema
+
+# Controls when the action will run. Triggers the workflow on push or pull request events
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+      APOLLO_VCS_COMMIT: ${{ github.event.pull_request_target.head.sha }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rover
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+      - name: Run check against main
+        run: |
+          rover config whoami
+          rover subgraph check --name metadata-api --schema schema.graphql infratographer@main


### PR DESCRIPTION
This adds the subgraph check as a pull_request_target action which allows it to run the version in main on PRs. This gives access to secrets which would not otherwise be available on forks. 