### PR TITLE
Update apollo studio check to download schema.graphql

### DIFF
--- a/.github/workflows/apollo-studio-checks.yml
+++ b/.github/workflows/apollo-studio-checks.yml
@@ -2,24 +2,47 @@ name: Check GraphQL Schema
 
 # Controls when the action will run. Triggers the workflow on push or pull request events
 on:
-  pull_request_target:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Save graphql.schema on PR"]
+    types:
+      - completed
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     env:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
       APOLLO_VCS_COMMIT: ${{ github.event.pull_request_target.head.sha }}
     steps:
-      - uses: actions/checkout@v2
+      - name: 'Download graphql from PR'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
 
       - name: Install Rover
         run: |
           curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
-      - name: Run check against main
+      - name: Run check against infratographer@main
         run: |
-          rover config whoami
           rover subgraph check --name metadata-api --schema schema.graphql infratographer@main


### PR DESCRIPTION
Take 2. This changes the workflow to run after we upload the graphql.schema in the PR. It downloads the PR and runs from `main` so it has access to the secret still.