### PR TITLE
Update metadata to be @shareable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,7 @@ dev-nats: ## Initializes nats
 	@date --rfc-3339=seconds
 	@.devcontainer/scripts/nats_account.sh
 
-generate: background-run .generate kill-running ## Generates code
-
-.generate: vendor
+generate: vendor
 	@echo --- Generating code...
 	@date --rfc-3339=seconds
 	@go generate ./...

--- a/internal/graphapi/generated.go
+++ b/internal/graphapi/generated.go
@@ -2061,7 +2061,7 @@ type MetadataNode @key(fields: "id") @interfaceObject {
   """
   Metadata about this node, including annotations and statuses.
   """
-  metadata: Metadata @goField(forceResolver: true)
+  metadata: Metadata @shareable @goField(forceResolver: true)
 }
 
 extend type Metadata {
@@ -2107,7 +2107,7 @@ extend type Metadata {
   """
   Metadata about this node, including annotations and statuses.
   """
-  metadata: Metadata @goField(forceResolver: true)
+  metadata: Metadata @shareable @goField(forceResolver: true)
 }
 
 extend type AnnotationNamespace {
@@ -2294,7 +2294,7 @@ type StatusNamespaceUpdatePayload {
   """
   Metadata about this node, including annotations and statuses.
   """
-  metadata: Metadata @goField(forceResolver: true)
+  metadata: Metadata @shareable @goField(forceResolver: true)
 }
 
 extend type StatusNamespace {

--- a/internal/testclient/schema/schema.graphql
+++ b/internal/testclient/schema/schema.graphql
@@ -336,7 +336,7 @@ type MetadataEdge {
 type MetadataNode @key(fields: "id") @interfaceObject {
 	id: ID!
 	"""Metadata about this node, including annotations and statuses."""
-	metadata: Metadata
+	metadata: Metadata @shareable
 }
 """Ordering options for Metadata connections"""
 input MetadataOrder {
@@ -501,7 +501,7 @@ type ResourceOwner @key(fields: "id") @interfaceObject {
 		where: AnnotationNamespaceWhereInput
 	): AnnotationNamespaceConnection!
 	"""Metadata about this node, including annotations and statuses."""
-	metadata: Metadata
+	metadata: Metadata @shareable
 }
 type Status implements Node @key(fields: "id") @prefixedID(prefix: "metasts") {
 	id: ID!
@@ -691,7 +691,7 @@ type StatusOwner @key(fields: "id") @interfaceObject {
 		where: StatusNamespaceWhereInput
 	): StatusNamespaceConnection!
 	"""Metadata about this node, including annotations and statuses."""
-	metadata: Metadata
+	metadata: Metadata @shareable
 }
 """Input information to update an status."""
 input StatusUpdateInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -323,7 +323,7 @@ type MetadataEdge {
 type MetadataNode @key(fields: "id") @interfaceObject {
 	id: ID!
 	"""Metadata about this node, including annotations and statuses."""
-	metadata: Metadata
+	metadata: Metadata @shareable
 }
 """Ordering options for Metadata connections"""
 input MetadataOrder {
@@ -488,7 +488,7 @@ type ResourceOwner @key(fields: "id") @interfaceObject {
 		where: AnnotationNamespaceWhereInput
 	): AnnotationNamespaceConnection!
 	"""Metadata about this node, including annotations and statuses."""
-	metadata: Metadata
+	metadata: Metadata @shareable
 }
 type Status implements Node @key(fields: "id") @prefixedID(prefix: "metasts") {
 	id: ID!
@@ -678,7 +678,7 @@ type StatusOwner @key(fields: "id") @interfaceObject {
 		where: StatusNamespaceWhereInput
 	): StatusNamespaceConnection!
 	"""Metadata about this node, including annotations and statuses."""
-	metadata: Metadata
+	metadata: Metadata @shareable
 }
 """Input information to update an status."""
 input StatusUpdateInput {

--- a/schema/metadata.graphql
+++ b/schema/metadata.graphql
@@ -12,7 +12,7 @@ type MetadataNode @key(fields: "id") @interfaceObject {
   """
   Metadata about this node, including annotations and statuses.
   """
-  metadata: Metadata @goField(forceResolver: true)
+  metadata: Metadata @shareable @goField(forceResolver: true)
 }
 
 extend type Metadata {

--- a/schema/resourceowner.graphql
+++ b/schema/resourceowner.graphql
@@ -34,7 +34,7 @@ type ResourceOwner @key(fields: "id") @interfaceObject {
   """
   Metadata about this node, including annotations and statuses.
   """
-  metadata: Metadata @goField(forceResolver: true)
+  metadata: Metadata @shareable @goField(forceResolver: true)
 }
 
 extend type AnnotationNamespace {

--- a/schema/statusowner.graphql
+++ b/schema/statusowner.graphql
@@ -34,7 +34,7 @@ type StatusOwner @key(fields: "id") @interfaceObject {
   """
   Metadata about this node, including annotations and statuses.
   """
-  metadata: Metadata @goField(forceResolver: true)
+  metadata: Metadata @shareable @goField(forceResolver: true)
 }
 
 extend type StatusNamespace {


### PR DESCRIPTION
Update `metadata` on the interfaceObjects defined in metadata-api to be `@shareable`. This allows us to implement multiple interfaceObjects with the same type within the metadata-api since the supergraph only seems to use 1 of the interfaceObject types when resolving things. Seems they are working through the bug we opened, so this is a workaround for the current problems we hit.