### PR TITLE
Update metadata-api chart

### DIFF
--- a/chart/metadata-api/templates/api-config.yaml
+++ b/chart/metadata-api/templates/api-config.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-config
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+data:
+  METADATAAPI_EVENTS_PUBLISHER_PREFIX: "{{ .Values.api.events.topicPrefix }}"
+  METADATAAPI_EVENTS_PUBLISHER_URL: "{{ .Values.api.events.connectionURL }}"
+  METADATAAPI_OIDC_ENABLED: "{{ .Values.api.oidc.enabled }}"
+  METADATAAPI_OIDC_AUDIENCE: "{{ .Values.api.oidc.audience }}"
+  METADATAAPI_OIDC_ISSUER: "{{ .Values.api.oidc.issuer }}"
+  METADATAAPI_OIDC_JWKS_REMOTE_TIMEOUT: "{{ .Values.api.oidc.jwksRemoteTimeout }}"
+  METADATAAPI_SERVER_LISTEN: ":{{ .Values.api.listenPort }}"
+  METADATAAPI_SERVER_SHUTDOWN_GRACE_PERIOD: "{{ .Values.api.shutdownGracePeriod }}"
+  METADATAAPI_PERMISSIONS_URL: "{{ .Values.api.permissions.url }}"
+{{- if .Values.api.tracing.enabled }}
+  METADATAAPI_TRACING_ENABLED: "{{ .Values.api.tracing.enabled }}"
+  METADATAAPI_TRACING_PROVIDER: "{{ .Values.api.tracing.provider }}"
+  METADATAAPI_TRACING_ENVIRONMENT: "{{ .Values.api.tracing.environment }}"
+{{- if eq .Values.api.tracing.provider "jaeger" }}
+  METADATAAPI_TRACING_JAEGER_ENDPOINT: "{{ .Values.api.tracing.jaeger.endpoint }}"
+  METADATAAPI_TRACING_JAEGER_USER: "{{ .Values.api.tracing.jaeger.user }}"
+  METADATA_TRACING_JAEGER_PASSWORD: "{{ .Values.api.tracing.jaeger.password }}"
+{{- end }}
+{{- if eq .Values.api.tracing.provider "otlpgrpc" }}
+  METADATAAPI_TRACING_OTLP_ENDPOINT: "{{ .Values.api.tracing.otlp.endpoint }}"
+  METADATAAPI_TRACING_OTLP_INSECURE: "{{ .Values.api.tracing.otlp.insecure }}"
+  METADATA_TRACING_OTLP_CERTIFICATE: "{{ .Values.api.tracing.otlp.certificate }}"
+{{- end }}
+{{- end }}
+{{- with .Values.api.trustedProxies }}
+  METADATAAPI_SERVER_TRUSTED_PROXIES: "{{ join " " . }}"
+{{- end }}

--- a/chart/metadata-api/templates/deployment.yaml
+++ b/chart/metadata-api/templates/deployment.yaml
@@ -40,9 +40,18 @@ spec:
       {{- if .Values.api.migrateOnInit  }}
       initContainers:
         - name: {{ .Chart.Name }}-migrate
+          {{- if .Values.api.extraEnvVars }}
+          env:
+          {{- range .Values.api.extraEnvVars }}
+            - name: {{ .name }}
+              value: {{ .value }}
+          {{- end }}
+          {{- end }}
           envFrom:
+          {{- if .Values.api.db.uriSecret }}
             - secretRef:
                 name: {{ .Values.api.db.uriSecret }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -59,45 +68,20 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.api.extraEnvVars }}
           env:
-            - name: METADATAAPI_SERVER_LISTEN
-              value: ":{{ .Values.api.listenPort }}"
-            - name: METADATAAPI_SERVER_SHUTDOWN_GRACE_PERIOD
-              value: "{{ .Values.api.shutdownGracePeriod }}"
-          {{- with .Values.api.trustedProxies }}
-            - name: METADATAAPI_SERVER_TRUSTED_PROXIES
-              value: "{{ join " " . }}"
+          {{- range .Values.api.extraEnvVars }}
+            - name: {{ .name }}
+              value: {{ .value }}
           {{- end }}
-            - name: METADATAAPI_NATS_URL
-              value: "{{ .Values.api.events.connectionURL }}"
-            - name: METADATAAPI_NATS_STREAM_NAME
-              value: "{{ .Values.api.events.queue | default "metadataapi" }}"
-            - name: METADATAAPI_NATS_SUBJECT_PREFIX
-              value: "{{ .Values.api.events.subjects }}"
-          {{- if .Values.api.events.auth.secretName }}
-            - name: METADATAAPI_NATS_CREDS_FILE
-              value: "{{ .Values.api.events.credsPath }}"
-          {{- end }}
-          {- if .Values.api.oidc.enabled }}
-          {{- with .Values.api.oidc.audience }}
-            - name: METADATAAPI_OIDC_AUDIENCE
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.api.oidc.issuer }}
-            - name: METADATAAPI_OIDC_ISSUER
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.api.oidc.jwks.remoteTimeout }}
-            - name: METADATAAPI_OIDC_JWKS_REMOTE_TIMEOUT
-              value: "{{ . }}"
-          {{- end }}
-          {{- else }}
-            - name: METADATAAPI_OIDC_ENABLED
-              value: "false"
-          {{- end }}
+          {{- end }} 
           envFrom:
+            - configMapRef:
+                name: {{ include "common.names.fullname" . }}-config
+          {{- if .Values.api.db.uriSecret }}
             - secretRef:
                 name: {{ .Values.api.db.uriSecret }}
+          {{- end }}
           {{- with .Values.api.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/chart/metadata-api/values.yaml
+++ b/chart/metadata-api/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/infratographer/metadata-api
   pullPolicy: IfNotPresent
-  tag: "v0.0.13"
+  tag: "main-latest"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -31,24 +31,25 @@ ingress:
 
 api:
   replicas: 1
-  listenPort: 7608
+  listenPort: 7610
   extraLabels: {}
   extraAnnotations: {}
-  extraEnvVars: {}
+  extraEnvVars []:
+  #- value: "postgresql://user@my-db-server:26257/metadata_api
+  #  name: METADATAAPI_CRDB_URI
   resources: {}
   podSecurityContext: {}
   securityContext: {}
   events:
-    connectionURL: "my-events-cluster.example.com:4222"
+    connectionURL: "nats://my-events-cluster.example.com:4222"
     auth:
-      secretName: "events-creds"
+      secretName: ""
       credsPath: "/nats/creds"
-    subjects: "events"
-    queue: "metadata"
+    topicPrefix: "com.infratographer"
   db:
-    uriSecret: metadata-api-db-uri
-    certSecret: metadata-api-db-ca
-  migrateOnInit: true
+    uriSecret: "" 
+    certSecret: ""
+  migrateOnInit: true 
 
   oidc:
     enabled: false
@@ -56,6 +57,29 @@ api:
     issuer: ""
     jwks:
       remoteTimeout: 1m
+
+  permissions:
+    url: ""
+
+  tracing:
+    # enabled is true if OpenTelemetry tracing should be enabled for permissions-api
+    enabled: false
+    # environment is the OpenTelemetry tracing environment to use
+    environment: ""
+    # provider is the OpenTelemetry tracing provider to use
+    provider: stdout
+    jaeger:
+      # endpoint is the Jaeger collector to send traces to
+      endpoint: ""
+      # user is the user to use when authenticating against the Jaeger deployment
+      user: ""
+      # password is the password to use when authenticating against the Jaeger deployment
+      password: ""
+    otlp:
+      # endpoint is the OpenTelemetry Protocol (OTLP) collector endpoint to send traces to
+      endpoint: ""
+      # insecure is true if TLS should not be required when sending traces
+      insecure: false
 
   shutdownGracePeriod: 5s
   trustedProxies: []


### PR DESCRIPTION
This PR updates chart to align with other chart configurations.
- allows for enabling tracing
- allows for adding connection uri via environment variables for easier local testing
- allows for enabling permissions api