### PR TITLE
Add permissions ignorenoresponders to helm chart

### DIFF
--- a/chart/metadata-api/templates/api-config.yaml
+++ b/chart/metadata-api/templates/api-config.yaml
@@ -22,6 +22,7 @@ data:
   METADATAAPI_SERVER_LISTEN: ":{{ .Values.api.listenPort }}"
   METADATAAPI_SERVER_SHUTDOWN_GRACE_PERIOD: "{{ .Values.api.shutdownGracePeriod }}"
   METADATAAPI_PERMISSIONS_URL: "{{ .Values.api.permissions.url }}"
+  METADATAAPI_PERMISSIONS_IGNORENORESPONDERS: "{{ .Values.api.permissions.ignoreNoResponders }}"
 {{- if .Values.api.tracing.enabled }}
   METADATAAPI_TRACING_ENABLED: "{{ .Values.api.tracing.enabled }}"
   METADATAAPI_TRACING_PROVIDER: "{{ .Values.api.tracing.provider }}"

--- a/chart/metadata-api/values.yaml
+++ b/chart/metadata-api/values.yaml
@@ -66,6 +66,8 @@ api:
 
   permissions:
     url: ""
+    # ignoreNoResponders whether or not to ignore errors when no AuthRelationship responders are available
+    ignoreNoResponders: false
 
   tracing:
     # enabled is true if OpenTelemetry tracing should be enabled for permissions-api

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.26.0
 	github.com/vektah/gqlparser/v2 v2.5.10
 	github.com/wundergraph/graphql-go-tools v1.67.0
-	go.infratographer.com/permissions-api v0.2.6
+	go.infratographer.com/permissions-api v0.2.7-0.20231103213152-84681822dedd
 	go.infratographer.com/x v0.3.9
 	go.uber.org/zap v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -593,8 +593,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-go.infratographer.com/permissions-api v0.2.6 h1:Xet3HF18SJHCoP5S3KTF7JAhD9RA1jGTa80QSII7ieY=
-go.infratographer.com/permissions-api v0.2.6/go.mod h1:2uNlcC/gsWXhxPaQ+NP/Kwf02Wu3bCPQ3FF7vGgbnwU=
+go.infratographer.com/permissions-api v0.2.7-0.20231103213152-84681822dedd h1:1PgyFVRttmnz5l1aIjZKft9Bd18DUZz6QBFSXZkhZc4=
+go.infratographer.com/permissions-api v0.2.7-0.20231103213152-84681822dedd/go.mod h1:2uNlcC/gsWXhxPaQ+NP/Kwf02Wu3bCPQ3FF7vGgbnwU=
 go.infratographer.com/x v0.3.9 h1:fsfF/w5zHgiNAHvYmvsWlICNha2X53WNLVSKOkyPnWo=
 go.infratographer.com/x v0.3.9/go.mod h1:n/61MZRKFbGlS8xUwAhTyDhqcL2Wk6uPsXADC2n5t1I=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
For environments where we do not have permissions consuming Auth-Relationship events, add ability to ignore the no responders error. 