### PR TITLE
fix: migrate cmd doesn't work when using HOST/USER/PASS DB config instead of URI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 	// Setup migrate command
 	goosex.RegisterCobraCommand(rootCmd, func() {
 		goosex.SetBaseFS(db.Migrations)
-		goosex.SetDBURI(config.AppConfig.CRDB.URI)
+		goosex.SetDBURI(config.AppConfig.CRDB.GetURI())
 		goosex.SetLogger(logger)
 	})
 }


### PR DESCRIPTION
Load the URI from the config using the function that will put together the URI if you pass a host, username, and password as seperate config options instead of passing the DB URI.