### PR TITLE
chore: use infratographer actions bot to commit go generate results

### DIFF
--- a/.github/workflows/renovate-generate.yml
+++ b/.github/workflows/renovate-generate.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.INFRATOGRAPHER_ACTIONS_BOT_TOKEN }}
 
       - name: Check if PR is from Renovate bot
         id: check_renovate
@@ -42,4 +43,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           message: "chore: run go generate"
+          author_name: Infratographer Actions Bot
+          author_email: actions-bot@infratographer.com
           commit: --signoff


### PR DESCRIPTION
According to the [docs](https://github.com/EndBug/add-and-commit?tab=readme-ov-file#about-tokens) you configure the push to use the bot token by updating the checkout action. 